### PR TITLE
add support for path mapping, fix context path, lift dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 > KumuluzEE OpenAPI project provides powerful tools to incorporate and visualize the OpenAPI 3 specification to your microservice.
 
 KumuluzEE OpenAPI project allows you to document microservice APIs using OpenAPI v3 compliant annotations. Project will automatically hook-up servlet that will 
-serve your API specifications on endpoint ```/api-specs/<jax-rs application-base-path>/openapi.[json|yaml]```. Furthermore, project allows you to integrate Swagger-UI into your
+serve your API specifications on endpoint ```/api-specs/openapi.[json|yaml]```. Furthermore, project allows you to integrate Swagger-UI into your
 microservice that will visualize APIs documentation and allow you to interact with your API resources.
  
 More details: [OpenAPI v3 Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md).
@@ -65,11 +65,11 @@ java -jar target/${project.build.finalName}.jar
 
 After startup API specification will be available at:
 
-**http://<-hostname-:<-port->/<-optional-context-path->/api-specs/<-application-base-path->/openapi.[json,yaml]**
+**http://<-hostname-:<-port->/<-optional-context-path->/api-specs/openapi.[json,yaml]**
 
 Example:
 
-http://localhost:8080/api-specs/v1/openapi.json
+http://localhost:8080/api-specs/openapi.json
 
 Serving OpenAPI specification can be disabled by setting property **kumuluzee.openapi.spec.enabled** to false. By default serving API spec is enabled.
 
@@ -87,7 +87,7 @@ kumuluzee:
       mapping: /custom/ui
 ```
 
-Remember that context path will be prefixed. One difference with `kumuluzee-openapi-mp` is that JAX-RS Application path is also appended after mapping.
+Remember that context path will be prefixed.
 
 ## Adding OpenAPI UI
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ kumuluzee:
 
 Remember that context path will be prefixed.
 
+If you deploy behind reverse proxy so that specification and UI are no longer reachable locally or by internal domain, you can override the base URL. Specification and UI mappings will be appended to this base.
+```yaml
+kumuluzee:
+  openapi:
+    base-url: http://behind.proxy.example.com
+```
+
 ## Adding OpenAPI UI
 
 To serve API specification in visual form and to allow API consumers to interact with API resources you can add OpenAPI UI by including dependency:

--- a/README.md
+++ b/README.md
@@ -65,13 +65,29 @@ java -jar target/${project.build.finalName}.jar
 
 After startup API specification will be available at:
 
-**http://<-hostname-:<-port->/api-specs/<-application-base-path->/openapi.[json,yaml]**
+**http://<-hostname-:<-port->/<-optional-context-path->/api-specs/<-application-base-path->/openapi.[json,yaml]**
 
 Example:
 
 http://localhost:8080/api-specs/v1/openapi.json
 
 Serving OpenAPI specification can be disabled by setting property **kumuluzee.openapi.spec.enabled** to false. By default serving API spec is enabled.
+
+### Mapping to different endpoint
+
+You can set a different servlet endpoint to serve the specification.
+```yaml
+kumuluzee:
+  openapi:
+    enabled: false
+    servlet:
+      mapping: /custom
+    ui:
+      enabled: true
+      mapping: /custom/ui
+```
+
+Remember that context path will be prefixed. One difference with `kumuluzee-openapi-mp` is that JAX-RS Application path is also appended after mapping.
 
 ## Adding OpenAPI UI
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,8 +3,8 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>kumuluzee-openapi-parent</artifactId>
         <groupId>com.kumuluz.ee.openapi</groupId>
+        <artifactId>kumuluzee-openapi-parent</artifactId>
         <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/core/src/main/java/com/kumuluz/ee/openapi/OpenApiExtension.java
+++ b/core/src/main/java/com/kumuluz/ee/openapi/OpenApiExtension.java
@@ -54,7 +54,7 @@ public class OpenApiExtension implements Extension {
                             .orElse("/api-specs");
                     mapping = prependAndStripSlash(mapping);
 
-                    specParams.put("openApi.configuration.location", mapping+"/openapi-configuration.json");
+                    specParams.put("openApi.configuration.location", "api-specs/openapi-configuration.json");
                     server.registerServlet(OpenApiServlet.class, mapping+"/*", specParams, 1);
 
                     LOG.info("OpenAPI extension initialized.");

--- a/core/src/main/java/com/kumuluz/ee/openapi/OpenApiExtension.java
+++ b/core/src/main/java/com/kumuluz/ee/openapi/OpenApiExtension.java
@@ -80,12 +80,14 @@ public class OpenApiExtension implements Extension {
 
                     applicationPath = StringUtils.strip(applicationPath, "/");
 
+                    String mapping = ConfigurationUtil.getInstance().get("kumuluzee.openapi.servlet.mapping").orElse("/api-specs");
+
                     if (applicationPath.equals("")) {
-                        specParams.put("openApi.configuration.location", "api-specs/openapi-configuration.json");
-                        server.registerServlet(OpenApiServlet.class, "/api-specs/*", specParams, 1);
+                        specParams.put("openApi.configuration.location", mapping+"/openapi-configuration.json");
+                        server.registerServlet(OpenApiServlet.class, mapping+"/*", specParams, 1);
                     } else {
-                        specParams.put("openApi.configuration.location", "api-specs/" + applicationPath + "/openapi-configuration.json");
-                        server.registerServlet(OpenApiServlet.class, "/api-specs/" + applicationPath + "/*", specParams, 1);
+                        specParams.put("openApi.configuration.location", mapping + "/" + applicationPath + "/openapi-configuration.json");
+                        server.registerServlet(OpenApiServlet.class, mapping+"/" + applicationPath + "/*", specParams, 1);
                     }
 
                     LOG.info("OpenAPI extension initialized.");

--- a/core/src/main/java/com/kumuluz/ee/openapi/OpenApiExtension.java
+++ b/core/src/main/java/com/kumuluz/ee/openapi/OpenApiExtension.java
@@ -9,13 +9,9 @@ import com.kumuluz.ee.common.wrapper.KumuluzServerWrapper;
 import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.jetty.JettyServletServer;
 import io.swagger.v3.jaxrs2.integration.OpenApiServlet;
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import org.apache.commons.lang3.StringUtils;
 
-import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.*;
 import java.util.logging.Logger;
 
@@ -51,44 +47,15 @@ public class OpenApiExtension implements Extension {
                 ServiceLoader.load(Application.class).forEach(applications::add);
 
                 if (applications.size() == 1) {
-                    Application application = applications.get(0);
 
                     Map<String, String> specParams = new HashMap<>();
 
-                    Class<?> applicationClass = application.getClass();
-                    if (targetClassIsProxied(applicationClass)) {
-                        applicationClass = applicationClass.getSuperclass();
-                    }
+                    String mapping = ConfigurationUtil.getInstance().get("kumuluzee.openapi.servlet.mapping")
+                            .orElse("/api-specs");
+                    mapping = prependAndStripSlash(mapping);
 
-                    String applicationPath = "";
-
-                    OpenAPIDefinition openAPIDefinitionAnnotation = applicationClass.getAnnotation(OpenAPIDefinition.class);
-
-                    ApplicationPath applicationPathAnnotation = applicationClass.getAnnotation(ApplicationPath.class);
-                    if (applicationPathAnnotation != null) {
-                        applicationPath = applicationPathAnnotation.value();
-                    } else {
-                        if (openAPIDefinitionAnnotation != null) {
-                            try {
-                                URL url = new URL(openAPIDefinitionAnnotation.servers()[0].url());
-                                applicationPath = url.getPath();
-                            } catch (MalformedURLException e) {
-                                LOG.warning("Server URL defined in annotation OpenAPIDefinition is invalid: " + e.getMessage());
-                            }
-                        }
-                    }
-
-                    applicationPath = StringUtils.strip(applicationPath, "/");
-
-                    String mapping = ConfigurationUtil.getInstance().get("kumuluzee.openapi.servlet.mapping").orElse("/api-specs");
-
-                    if (applicationPath.equals("")) {
-                        specParams.put("openApi.configuration.location", mapping+"/openapi-configuration.json");
-                        server.registerServlet(OpenApiServlet.class, mapping+"/*", specParams, 1);
-                    } else {
-                        specParams.put("openApi.configuration.location", mapping + "/" + applicationPath + "/openapi-configuration.json");
-                        server.registerServlet(OpenApiServlet.class, mapping+"/" + applicationPath + "/*", specParams, 1);
-                    }
+                    specParams.put("openApi.configuration.location", mapping+"/openapi-configuration.json");
+                    server.registerServlet(OpenApiServlet.class, mapping+"/*", specParams, 1);
 
                     LOG.info("OpenAPI extension initialized.");
                 } else {
@@ -100,5 +67,10 @@ public class OpenApiExtension implements Extension {
 
     private boolean targetClassIsProxied(Class targetClass) {
         return targetClass.getCanonicalName().contains("$Proxy");
+    }
+
+    public static String prependAndStripSlash(String s) {
+        if (!s.startsWith("/")) s = s+"/";
+        return StringUtils.stripEnd(s, "/");
     }
 }

--- a/core/src/main/java/com/kumuluz/ee/openapi/processor/JaxRsOpenApiAnnotationProcessor.java
+++ b/core/src/main/java/com/kumuluz/ee/openapi/processor/JaxRsOpenApiAnnotationProcessor.java
@@ -3,6 +3,7 @@ package com.kumuluz.ee.openapi.processor;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.kumuluz.ee.configuration.utils.ConfigurationUtil;
 import com.kumuluz.ee.openapi.models.OpenApiConfiguration;
 import com.kumuluz.ee.openapi.utils.AnnotationProcessorUtil;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
@@ -156,24 +157,17 @@ public class JaxRsOpenApiAnnotationProcessor extends AbstractProcessor {
                     oac.setPrettyPrint(true);
                     if (applicationElementNames.size() == 1) {
                         oac.setResourcePackages(resourceElementNames);
+
+                        //Blacklist
+                        oac.getResourcePackages().remove("org.glassfish.jersey.server.wadl");
                     }
 
                     oac.setOpenAPI(openAPI);
 
                     try {
-
                         String jsonOAC = mapper.writeValueAsString(oac);
 
-                        String path = new URL(openAPI.getServers().get(0).getUrl()).getPath();
-
-                        path = StringUtils.strip(path, "/");
-
-                        if (path.equals("")) {
-                            AnnotationProcessorUtil.writeFile(jsonOAC, "api-specs/openapi-configuration.json", filer);
-                        } else {
-                            AnnotationProcessorUtil.writeFile(jsonOAC, "api-specs/" + path + "/openapi-configuration.json", filer);
-                        }
-
+                        AnnotationProcessorUtil.writeFile(jsonOAC, "api-specs/openapi-configuration.json", filer);
                     } catch (IOException e) {
                         LOG.warning(e.getMessage());
                     }

--- a/openapi-ui/pom.xml
+++ b/openapi-ui/pom.xml
@@ -3,8 +3,8 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>kumuluzee-openapi-parent</artifactId>
         <groupId>com.kumuluz.ee.openapi</groupId>
+        <artifactId>kumuluzee-openapi-parent</artifactId>
         <version>1.1.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/openapi-ui/src/main/java/com/kumuluz/ee/openapi/ui/OpenApiUiExtension.java
+++ b/openapi-ui/src/main/java/com/kumuluz/ee/openapi/ui/OpenApiUiExtension.java
@@ -99,7 +99,6 @@ public class OpenApiUiExtension implements Extension {
                         .getBoolean("kumuluzee.openapi.enabled").orElse(true)) {
 
                     LOG.info("Swagger UI servlet registered on "+uiPath+ " (servlet context is implied)");
-                    LOG.info("Swagger UI can be accessed at "+serverUrl + contextPath + uiPath);
 
                     // create servlet that will serve static files
                     Map<String, String> swaggerUiParams = new HashMap<>();
@@ -107,17 +106,22 @@ public class OpenApiUiExtension implements Extension {
                     swaggerUiParams.put("uiPath", uiPath); //context already included in servlet resolution
                     server.registerServlet(UiServlet.class, uiPath + "/*", swaggerUiParams, 1);
 
-                    String specUrl = serverUrl + contextPath + specPath;
-                    String oauth2RedirectUrl = serverUrl + contextPath + uiPath;
+                    //Used to override base URL when deploying behind reverse proxy
+                    String baseUrl = configurationUtil.get("kumuluzee.openapi.base-url")
+                            .orElse(serverUrl + contextPath);
+
+                    String specUrl = baseUrl + specPath;
+                    String uiBaseUrl = baseUrl + uiPath;
                     String redirUiPath = contextPath+uiPath;
 
+                    LOG.info("Swagger UI can be accessed at "+uiBaseUrl);
                     LOG.info("Swagger UI spec URL resolved to "+specUrl+"/openapi.json");
 
                     // create filter that will redirect to Swagger UI with appropriate parameters
                     Map<String, String> swaggerUiFilterParams = new HashMap<>();
                     swaggerUiFilterParams.put("specUrl", specUrl);
                     swaggerUiFilterParams.put("uiPath", redirUiPath);
-                    swaggerUiFilterParams.put("oauth2RedirectUrl", oauth2RedirectUrl + "/oauth2-redirect.html");
+                    swaggerUiFilterParams.put("oauth2RedirectUrl", uiBaseUrl + "/oauth2-redirect.html");
                     server.registerFilter(SwaggerUIFilter.class, uiPath + "/*", swaggerUiFilterParams);
 
                 } else {

--- a/openapi-ui/src/main/java/com/kumuluz/ee/openapi/ui/servlets/UiServlet.java
+++ b/openapi-ui/src/main/java/com/kumuluz/ee/openapi/ui/servlets/UiServlet.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2014-2017 Kumuluz and/or its affiliates
+ *  and other contributors as indicated by the @author tags and
+ *  the contributor list.
+ *
+ *  Licensed under the MIT License (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  https://opensource.org/licenses/MIT
+ *
+ *  The software is provided "AS IS", WITHOUT WARRANTY OF ANY KIND, express or
+ *  implied, including but not limited to the warranties of merchantability,
+ *  fitness for a particular purpose and noninfringement. in no event shall the
+ *  authors or copyright holders be liable for any claim, damages or other
+ *  liability, whether in an action of contract, tort or otherwise, arising from,
+ *  out of or in connection with the software or the use or other dealings in the
+ *  software. See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.kumuluz.ee.openapi.ui.servlets;
+
+import org.eclipse.jetty.servlet.DefaultServlet;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Logger;
+import org.eclipse.jetty.util.resource.Resource;
+
+import javax.servlet.UnavailableException;
+
+/**
+ * Static file server for Swagger UI, modified to remove relative UI path when looking for resources.
+ *
+ * @author Urban Malc
+ * @since 1.1.0
+ */
+public class UiServlet extends DefaultServlet {
+
+    private static final Logger LOG = Log.getLogger(UiServlet.class);
+
+    private String uiPath;
+
+    @Override
+    public void init() throws UnavailableException {
+        super.init();
+        uiPath = getInitParameter("uiPath");
+    }
+
+    @Override
+    public Resource getResource(String pathInContext) {
+
+        if (pathInContext.startsWith(this.uiPath)) {
+            // request starts with path (as it should), remove path when looking for static files
+            pathInContext = pathInContext.substring(uiPath.length());
+        } else {
+            // this should be unreachable, since this servlet should be mapped to uiPath/*
+            LOG.warn("Could not remove uiPath (" + uiPath + ") from path: " + pathInContext);
+            return null;
+        }
+
+        return super.getResource(pathInContext);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -28,13 +28,13 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <kumuluzee.version>3.3.0</kumuluzee.version>
+        <kumuluzee.version>3.8.0</kumuluzee.version>
 
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <nexus.staging.plugin.version>1.6.8</nexus.staging.plugin.version>
         <gpg.plugin.version>1.6</gpg.plugin.version>
-        <swagger.version>2.0.7</swagger.version>
-        <swagger-ui.version>3.22.0</swagger-ui.version>
+        <swagger.version>2.1.2</swagger.version>
+        <swagger-ui.version>3.25.0</swagger-ui.version>
         <jersey-container-servlet.version>2.28</jersey-container-servlet.version>
         <jackson-dataformat-csv.version>2.9.8</jackson-dataformat-csv.version>
         <commons.version>3.8.1</commons.version>


### PR DESCRIPTION
1. Add custom servlet mapping for spec and UI
2. Remove Application path and OpenapiDefinition servers from path building.
3. Add full base URL override config for deployments behind proxy.
4. When UI is enabled, print spec and UI URL in log for quick access.